### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/libsaas/http.py
+++ b/libsaas/http.py
@@ -49,7 +49,7 @@ class Request(object):
         self.headers = headers if headers is not None else {}
 
     def __repr__(self):
-        return "<Request [%s %s] at 0x%x>" % (self.method, self.uri,
+        return "<Request [{0!s} {1!s}] at 0x{2:x}>".format(self.method, self.uri,
                                               id(self))
 
     def __eq__(self, other):

--- a/libsaas/scripts/saas.py
+++ b/libsaas/scripts/saas.py
@@ -21,11 +21,11 @@ def extract_action(instance, parser, args):
         resource = getattr(resource, current, None)
 
         if not resource:
-            parser.error('no such resource %s' % args[0])
+            parser.error('no such resource {0!s}'.format(args[0]))
         if getattr(resource, 'is_apimethod', False):
             return resource, args[1:]
         if not isinstance(resource, collections.Callable):
-            parser.error('no such resource %s' % args[0])
+            parser.error('no such resource {0!s}'.format(args[0]))
 
         # consume one token
         args.pop(0)
@@ -77,12 +77,12 @@ def parse_args(args):
         module = __import__('libsaas.services', globals(), locals(), [service])
         module = getattr(module, service)
     except (ImportError, AttributeError):
-        parser.error('no such service %s' % service)
+        parser.error('no such service {0!s}'.format(service))
 
     members = inspect.getmembers(module, lambda obj: inspect.isclass(obj) and
                                  issubclass(obj, base.Resource))
     if not members:
-        parser.error('no such service %s' % service)
+        parser.error('no such service {0!s}'.format(service))
 
     _, klass = members[0]
 
@@ -97,7 +97,7 @@ def parse_args(args):
         optargs = {'dest': argname}
         if default is not None:
             optargs.update({'default': default})
-        parser.add_option('--%s' % argname, **optargs)
+        parser.add_option('--{0!s}'.format(argname), **optargs)
 
     options, args = parser.parse_args(args)
 
@@ -108,7 +108,7 @@ def parse_args(args):
                                 [module_name])
             module = getattr(module, module_name)
         except ImportError:
-            parser.error('no such executor %s' % options.executor)
+            parser.error('no such executor {0!s}'.format(options.executor))
 
         module.use()
 

--- a/libsaas/services/desk/cases.py
+++ b/libsaas/services/desk/cases.py
@@ -67,7 +67,7 @@ class Cases(CasesBase):
 class Case(CasesBase):
 
     def __init__(self, parent, object_id, is_external=False):
-        case_id = 'e-%s' % object_id if is_external else object_id
+        case_id = 'e-{0!s}'.format(object_id) if is_external else object_id
         super(Case, self).__init__(parent, case_id)
 
     @base.apimethod

--- a/test/test_bitly.py
+++ b/test/test_bitly.py
@@ -61,18 +61,18 @@ class BitlyTestCase(unittest.TestCase):
             method = getattr(self.service.user(), method_name)
 
             method()
-            self.expect('GET', '/user/%s' % method_name, {})
+            self.expect('GET', '/user/{0!s}'.format(method_name), {})
             method(timezone='Europe/Andorra')
-            self.expect('GET', '/user/%s' % method_name, {
+            self.expect('GET', '/user/{0!s}'.format(method_name), {
                 'timezone': 'Europe/Andorra'
             })
             method(timezone='Europe/Andorra', unit='month')
-            self.expect('GET', '/user/%s' % method_name, {
+            self.expect('GET', '/user/{0!s}'.format(method_name), {
                 'unit': 'month',
                 'timezone': 'Europe/Andorra'
             })
             method(timezone='Europe/Andorra', unit='month')
-            self.expect('GET', '/user/%s' % method_name, {
+            self.expect('GET', '/user/{0!s}'.format(method_name), {
                 'unit': 'month',
                 'timezone': 'Europe/Andorra'
             })
@@ -83,7 +83,7 @@ class BitlyTestCase(unittest.TestCase):
             method = getattr(
                     self.service.link(link='http://foo.bar'), method_name)
             method()
-            self.expect('GET', '/link/%s' % method_name, {
+            self.expect('GET', '/link/{0!s}'.format(method_name), {
                 'link': 'http://foo.bar'
             })
 
@@ -104,22 +104,22 @@ class BitlyTestCase(unittest.TestCase):
                     self.service.link(link='http://foo.bar'), method_name)
 
             method()
-            self.expect('GET', '/link/%s' % method_name, {
+            self.expect('GET', '/link/{0!s}'.format(method_name), {
                 'link': 'http://foo.bar'
             })
             method(timezone='Europe/Andorra')
-            self.expect('GET', '/link/%s' % method_name, {
+            self.expect('GET', '/link/{0!s}'.format(method_name), {
                 'link': 'http://foo.bar',
                 'timezone': 'Europe/Andorra'
             })
             method(timezone='Europe/Andorra', unit='month')
-            self.expect('GET', '/link/%s' % method_name, {
+            self.expect('GET', '/link/{0!s}'.format(method_name), {
                 'link': 'http://foo.bar',
                 'unit': 'month',
                 'timezone': 'Europe/Andorra'
             })
             method(timezone='Europe/Andorra', unit='month')
-            self.expect('GET', '/link/%s' % method_name, {
+            self.expect('GET', '/link/{0!s}'.format(method_name), {
                 'link': 'http://foo.bar',
                 'unit': 'month',
                 'timezone': 'Europe/Andorra'


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:libsaas?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:runt18:libsaas?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
